### PR TITLE
Profile page

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,11 +22,6 @@
     "react-twitter-embed": "^4.0.4",
     "web-vitals": "^2.1.4"
   },
-  "jest":{
-    "verbose": true,
-     "testTimeout": 20000
-
-  },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,11 @@
     "react-twitter-embed": "^4.0.4",
     "web-vitals": "^2.1.4"
   },
+  "jest":{
+    "verbose": true,
+     "testTimeout": 20000
+
+  },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",

--- a/src/App.js
+++ b/src/App.js
@@ -9,6 +9,7 @@ import { GameTest } from "./components/gameTesting";
 import { Box, ChakraProvider, extendTheme } from "@chakra-ui/react";
 import { Loading } from "./components/loadingScreen";
 import { Selection } from "./components/groupselection";
+import { Profile } from "./components/profile";
 
 function App() {
     const accounts = [
@@ -31,8 +32,9 @@ function App() {
     */
     const [accs, setAccs] = useState([]);
     /* State of game to determine which component to render
-    0 - Default, render group select screen [TODO]
-    1 - Start of game [FOR NOW, DEFAULT]
+    -1 - Profile page
+    0 - Default, render group select screen [DEFAULT]
+    1 - Start of game 
     2 - On submit score screen
     3 - On highscore screen
     */
@@ -47,7 +49,7 @@ function App() {
     // useEffect that sets up supabase to update session everytime auth updates
     useEffect(() => {
         // Taken from supabase docs - sets session
-        setSession(supabase.auth.session())
+        setSession(supabase.auth.session());
         supabase.auth.onAuthStateChange((_event, session) => {
             setSession(session);
             // If session is not null, it means someone just logged in. Hence, handle profile.
@@ -60,28 +62,38 @@ function App() {
     }, []);
 
     let displayComponent;
-    if (gameState === 0) {
+    if (gameState === -1) {
         displayComponent = (
-            <Selection 
+            <Profile
                 session={session}
-                setGameState={setGameState} 
-                accs = {accs}
-                setAccs={setAccs} 
+                setGameState={setGameState}
+                setAccs={setAccs}
             />
         );
     }
-    if (gameState === 1){
-        console.log("starting to load")
-        console.log(accs)
+    if (gameState === 0) {
+        displayComponent = (
+            <Selection
+                session={session}
+                setGameState={setGameState}
+                accs={accs}
+                setAccs={setAccs}
+            />
+        );
+    }
+    if (gameState === 1) {
+        console.log("starting to load");
+        console.log(accs);
         displayComponent = (
             //<div>{JSON.stringify(session)}</div>
-            
+
             <Loading
                 accounts={accs}
                 setGameState={setGameState}
                 colorToggle={toggle}
             />
-        );}
+        );
+    }
     if (gameState === 2)
         displayComponent = (
             <SubmitScore
@@ -98,6 +110,7 @@ function App() {
     return (
         <Box className="App">
             <Nav
+                setGameState={setGameState}
                 session={session}
                 setSession={setSession}
                 setToggle={setToggle}

--- a/src/components/nav.js
+++ b/src/components/nav.js
@@ -10,7 +10,7 @@ import {
 
 import { signInWithTwitter, signOut } from "../logic/auth";
 
-export const Nav = ({ setToggle, session }) => {
+export const Nav = ({ setToggle, session, setGameState }) => {
     const { colorMode, toggleColorMode } = useColorMode();
     useEffect(() => {
         setToggle(colorMode);
@@ -27,6 +27,19 @@ export const Nav = ({ setToggle, session }) => {
                     That?
                 </Heading>
                 <Flex>
+                    <Box>
+                        {session ? (
+                            <Button
+                                onClick={() => setGameState(-1)}
+                                marginRight="20px"
+                            >
+                                Profile
+                            </Button>
+                        ) : (
+                            <></>
+                        )}
+                    </Box>
+
                     <Button
                         marginRight={"20px"}
                         id="toggle"
@@ -39,10 +52,14 @@ export const Nav = ({ setToggle, session }) => {
                     </Button>
                     <Box>
                         {session ? (
-                            <Button onClick={() => {
-                                signOut();
-                                window.location.reload(false);
-                            }}>Sign Out</Button>
+                            <Button
+                                onClick={() => {
+                                    signOut();
+                                    window.location.reload(false);
+                                }}
+                            >
+                                Sign Out
+                            </Button>
                         ) : (
                             <Button onClick={signInWithTwitter}>Sign In</Button>
                         )}

--- a/src/components/nav.js
+++ b/src/components/nav.js
@@ -19,7 +19,11 @@ export const Nav = ({ setToggle, session, setGameState }) => {
     return (
         <Flex h="100px" padding="10px 30px" align="center">
             <Flex as="nav" id="navbar" basis="100%" justify="space-between">
-                <Heading as="h2">
+                <Heading
+                    as="h2"
+                    cursor="pointer"
+                    onClick={() => setGameState(0)}
+                >
                     Who{" "}
                     <Text as="span" color="#00acee">
                         Tweeted

--- a/src/components/profile.js
+++ b/src/components/profile.js
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { resetData } from "../data/bufferData";
 import { Box } from "@chakra-ui/react";
 import { UserInfo } from "./userInfo";
+import { UserScores } from "./userScores";
 
 export const Profile = ({ session, setGameState, setAccs }) => {
     // On load, reset game data - because players may access profile page while active game is running.
@@ -11,11 +12,16 @@ export const Profile = ({ session, setGameState, setAccs }) => {
         if (session === null) {
             setGameState(0);
         }
-    });
+    }, []);
 
     return (
         <Box>
             <UserInfo session={session} />
+            <UserScores
+                session={session}
+                setGameState={setGameState}
+                setAccs={setAccs}
+            />
         </Box>
     );
 };

--- a/src/components/profile.js
+++ b/src/components/profile.js
@@ -1,0 +1,21 @@
+import { useEffect } from "react";
+import { resetData } from "../data/bufferData";
+import { Box } from "@chakra-ui/react";
+import { UserInfo } from "./userInfo";
+
+export const Profile = ({ session, setGameState, setAccs }) => {
+    // On load, reset game data - because players may access profile page while active game is running.
+    useEffect(() => {
+        resetData();
+        // In rare case that someone accesses while not logged in, return to selection
+        if (session === null) {
+            setGameState(0);
+        }
+    });
+
+    return (
+        <Box>
+            <UserInfo session={session} />
+        </Box>
+    );
+};

--- a/src/components/userInfo.js
+++ b/src/components/userInfo.js
@@ -1,0 +1,34 @@
+import { Box, Flex, Image, Heading, Text, Link } from "@chakra-ui/react";
+
+export const UserInfo = ({ session }) => {
+    return (
+        <Box>
+            <Flex align="center" margin="20px">
+                <Image
+                    margin="0px 20px"
+                    borderRadius={"50px"}
+                    width="100px"
+                    height="100px"
+                    src={session["user"]["user_metadata"]["avatar_url"].replace(
+                        "_normal",
+                        ""
+                    )}
+                ></Image>
+                <Flex direction="column">
+                    <Link
+                        isExternal={true}
+                        href={`https://www.twitter.com/${session["user"]["user_metadata"]["user_name"]}`}
+                    >
+                        <Heading>
+                            {session["user"]["user_metadata"]["full_name"]}
+                        </Heading>
+                    </Link>
+
+                    <Text>
+                        @{session["user"]["user_metadata"]["user_name"]}
+                    </Text>
+                </Flex>
+            </Flex>
+        </Box>
+    );
+};

--- a/src/components/userScores.js
+++ b/src/components/userScores.js
@@ -1,0 +1,90 @@
+import { Box, Flex, Button, Heading, Text, Link } from "@chakra-ui/react";
+import { useEffect, useState } from "react";
+import { handlesToAccs } from "../logic/helpers";
+import { idToHandles } from "../supabase/groupFunctions";
+import { getProfileHelper } from "../supabase/leaderboardFunctions";
+
+export const UserScores = ({ session, setGameState, setAccs }) => {
+    // State to store the groups that the user has played in before
+    const [groups, setGroups] = useState([]);
+    // State to handle initial loading of groups
+    const [loading, setLoading] = useState(true);
+
+    // Query database on load to retrieve groups.
+    useEffect(() => {
+        async function retrieveGroups() {
+            const data = await getProfileHelper(session["user"]["id"]);
+            // For each entry, convert id to handles and store in groups array
+            const toGroups = [];
+            for (let i = 0; i < data.length; i++) {
+                const handles = await idToHandles(data[i]["groupID"]);
+                const obj = {
+                    handles: handles,
+                    score: data[i]["score"],
+                };
+                toGroups.push(obj);
+            }
+            setGroups(toGroups);
+            setLoading(false);
+        }
+        retrieveGroups();
+    }, []);
+
+    return (
+        <Box>
+            {loading ? (
+                <>Loading...</>
+            ) : (
+                <Flex margin="50px 50px" direction="column" justify="center">
+                    <Flex margin="10px 0px" justify="space-between">
+                        <Text width="80%" fontSize="24px" fontWeight="bold">
+                            Group
+                        </Text>
+                        <Text fontSize="24px" fontWeight="bold">
+                            Score
+                        </Text>
+                        <Button visibility="hidden">Play</Button>
+                    </Flex>
+                    {groups.map((group, i) => {
+                        return (
+                            <Flex
+                                margin="10px 0px"
+                                justify="space-between"
+                                key={i}
+                                align="center"
+                            >
+                                <Box width="80%" overflow="hidden">
+                                    {group.handles.map((handle, i) => {
+                                        return (
+                                            <Text
+                                                fontStyle="italic"
+                                                key={i}
+                                                as="span"
+                                                marginRight="10px"
+                                            >
+                                                @{handle}
+                                            </Text>
+                                        );
+                                    })}
+                                </Box>
+                                {group.score}{" "}
+                                <Button
+                                    onClick={async () => {
+                                        setLoading(true);
+                                        const accs = await handlesToAccs(
+                                            group.handles
+                                        );
+                                        setAccs(accs);
+                                        setGameState(1);
+                                    }}
+                                >
+                                    Play
+                                </Button>
+                            </Flex>
+                        );
+                    })}
+                </Flex>
+            )}
+        </Box>
+    );
+};

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,0 +1,1 @@
+jest.setTimeout(15000);

--- a/src/supabase/groupFunctions.js
+++ b/src/supabase/groupFunctions.js
@@ -66,3 +66,25 @@ export const generateGroupID = (handles) => {
     }
     return handles.sort().join("");
 };
+
+/*
+    idToHandles - generates array of handles from unique group ID that already exists in table.
+    @param id - String representing the unique group ID
+    @return Array of twitter handles
+*/
+export const idToHandles = async (id) => {
+    const { data, error } = await supabase
+        .from("Group")
+        .select("*")
+        .eq("id", id);
+    if (error != null) return error;
+    if (data.length === 0) return "Group does not exist";
+
+    const ans = [];
+    for (const property in data[0]) {
+        if (property !== "id" && data[0][property] != null) {
+            ans.push(data[0][property]);
+        }
+    }
+    return ans;
+};

--- a/src/supabase/leaderboardFunctions.js
+++ b/src/supabase/leaderboardFunctions.js
@@ -125,3 +125,37 @@ export const deleteLBEntryAnon = async (groupID, playerNameAnon, score) => {
         .eq("score", score);
     return data;
 };
+
+/*
+    getProfileLB - Get all entries in the leaderboard by profile id. 
+    @param userID - ID of user
+    @return Array of javascript objects representing rows in database
+*/
+export const getProfileLB = async (playerID) => {
+    const { data, error } = await supabase
+        .from("Leaderboard")
+        .select("*")
+        .eq("playerID", playerID);
+    if (error != null) {
+        console.log(error);
+        return error;
+    }
+    return data;
+};
+
+/*
+    getProfileHelper - Get all relevant info by playerID, to be used in profile page.
+    @param userID - ID of user
+    @return Array of javascript objects representing top scores for the user.
+*/
+export const getProfileHelper = async (playerID) => {
+    const data = await getProfileLB(playerID);
+    const ans = [];
+    for (let i = 0; i < data.length; i++) {
+        const obj = {};
+        obj["groupID"] = data[i]["groupID"];
+        obj["score"] = data[i]["score"];
+        ans.push(obj);
+    }
+    return ans;
+};

--- a/src/testing/Api.test.js
+++ b/src/testing/Api.test.js
@@ -23,3 +23,4 @@ test("correctly fetches tweet info", () => {
         );
     });
 });
+

--- a/src/testing/groupFunctions.test.js
+++ b/src/testing/groupFunctions.test.js
@@ -2,6 +2,7 @@ import {
     newGroup,
     isDuplicate,
     generateGroupID,
+    idToHandles,
 } from "../supabase/groupFunctions";
 
 test("generateGroupID correctly generates string representing the sorted array concatenated together", () => {
@@ -25,4 +26,17 @@ test("isDuplicate correctly returns true for an entry that is not inside the dat
     ]).then((response) => {
         expect(response).toBe(true);
     });
+});
+
+test("idToHandles correctly converts id to handle array", () => {
+    return idToHandles("aocberniesandersdonaldjtrumpjrpotustedcruz").then(
+        (response) => {
+            expect(response.length).toBe(5);
+            expect(response[0]).toBe("aoc");
+            expect(response[1]).toBe("berniesanders");
+            expect(response[2]).toBe("donaldjtrumpjr");
+            expect(response[3]).toBe("potus");
+            expect(response[4]).toBe("tedcruz");
+        }
+    );
 });

--- a/src/testing/leaderboardFunctions.test.js
+++ b/src/testing/leaderboardFunctions.test.js
@@ -6,6 +6,7 @@ import {
     dataIfExists,
     updateLB,
     deleteLBEntry,
+    getProfileHelper,
 } from "../supabase/leaderboardFunctions";
 
 test("newLBEntryAnon correctly inserts an anoynmous entry in the leaderboard database that is detected by getGroupLB", () => {
@@ -92,6 +93,15 @@ test("updateLBEntry does not update when score is lower", () => {
         });
 });
 
+test("getProfileHelper correctly returns relevant info for user", () => {
+    return getProfileHelper("46a60792-a172-4f18-b737-376296165388").then(
+        (response) => {
+            expect(response.length).toBe(1);
+            expect(response[0]["groupID"]).toBe("JestTestGroup");
+            expect(response[0]["score"]).toBe(11);
+        }
+    );
+});
 test("Delete test entries for cleanup", () => {
     return deleteLBEntry(
         "JestTestGroup",


### PR DESCRIPTION
Added basic "Profile Page" that displays user information and **all previously played groups** + scores, allowing users to quickly start games for previously played groups

- Added profile page to navbar
- Added support to pull user info from session to display on profile page
- Retrieve previously played groups
  - Added database functions to get leaderboard entries for specific player (+ unit tests)
  - Added database functions to convert groupID to list of handles (+ unit tests)
  - Integrate above into frontend with session